### PR TITLE
Add check for null when adding parameters to the url query params.

### DIFF
--- a/templates/typescript/angular/4.0/client.hbs
+++ b/templates/typescript/angular/4.0/client.hbs
@@ -45,7 +45,7 @@ export class {{options.clientName}}{{#if options.generateInterface}} implements 
 
     let gl$params = new HttpParams();
     {{#query}}
-    if ({{camlCase name}} !== undefined) {
+    if ({{camlCase name}} !== undefined && {{camlCase name}} !== null) {
       gl$params = gl$params.set('{{name}}', String({{camlCase name}}));
     }
     {{/query}}

--- a/templates/typescript/angular/6.0/client.hbs
+++ b/templates/typescript/angular/6.0/client.hbs
@@ -44,7 +44,7 @@ export class {{options.clientName}}{{#if options.generateInterface}} implements 
 
     let gl$params = new HttpParams();
     {{#query}}
-    if ({{camlCase name}} !== undefined) {
+    if ({{camlCase name}} !== undefined && {{camlCase name}} !== null) {
       gl$params = gl$params.set('{{name}}', String({{camlCase name}}));
     }
     {{/query}}


### PR DESCRIPTION
Currently, the parameter is only omitted if the parameter is set to undefined. Need to check against null as well.